### PR TITLE
Added public method to get the authorization URL and get JWKS only when JWT is signed with RSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 * Added the `getAuthorizationURL` method to get the authorization URL without the redirect
-* Allow to turn off signature verification
 
 ## [1.1.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.3]
+
+### Added
+* Added the `getAuthorizationURL` method to get the authorization URL without the redirect
+
 ## [1.1.2]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 * Added the `getAuthorizationURL` method to get the authorization URL without the redirect
+* Get JWKS only when JWT is signed with RSA
 
 ## [1.1.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 * Added the `getAuthorizationURL` method to get the authorization URL without the redirect
+* Allow to turn off signature verification
 
 ## [1.1.2]
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -357,9 +357,6 @@ class OpenIDConnectClient
 
             // Verify the signature
             if ($this->canVerifySignatures()) {
-                if (!$this->getProviderConfigValue('jwks_uri')) {
-                    throw new OpenIDConnectClientException ('Unable to verify signature due to no jwks_uri being defined');
-                }
                 if (!$this->verifyJWTsignature($token_json->id_token)) {
                     throw new OpenIDConnectClientException ('Unable to verify signature');
                 }
@@ -1036,6 +1033,9 @@ class OpenIDConnectClient
                 $hashtype = 'sha' . substr($header->alg, 2);
                 $signatureType = $header->alg === 'PS256' ? 'PSS' : '';
                 
+                if (!$this->getProviderConfigValue('jwks_uri')) {
+                    throw new OpenIDConnectClientException ('Unable to verify signature due to no jwks_uri being defined');
+                }
                 $jwks = json_decode($this->fetchURL($this->getProviderConfigValue('jwks_uri')));
                 if ($jwks === NULL) {
                     throw new OpenIDConnectClientException('Error decoding JSON from jwks_uri');

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -662,14 +662,13 @@ class OpenIDConnectClient
         };
     }
 
-    /**
-     * Start Here
-     * @return void
-     * @throws OpenIDConnectClientException
-     */
-    private function requestAuthorization() {
-
-        $auth_endpoint = $this->getProviderConfigValue('authorization_endpoint');
+   /**
+    * Get the authorization URL
+    *
+    * @return string
+    */
+   public function getAuthorizationURL() {
+	$auth_endpoint = $this->getProviderConfigValue('authorization_endpoint');
         $response_type = 'code';
 
         // State essentially acts as a session key for OIDC
@@ -714,6 +713,16 @@ class OpenIDConnectClient
         }
 
         $auth_endpoint .= (strpos($auth_endpoint, '?') === false ? '?' : '&') . http_build_query($auth_params, '', '&', $this->encType);
+	return $auth_endpoint;
+   }
+
+    /**
+     * Start Here
+     * @return void
+     * @throws OpenIDConnectClientException
+     */
+    private function requestAuthorization() {
+        $auth_endpoint = $this->getAuthorizationURL();
 
         $this->commitSession();
         $this->redirect($auth_endpoint);

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -133,12 +133,6 @@ class OpenIDConnectClient
      * @var bool Verify peer hostname on transactions
      */
     private $verifyHost = true;
-    
-    /**
-     * @var bool Verify JWT signature
-     *
-     */
-    public  $verifySignature = true;
 
     /**
      * @var string if we acquire an access token it will be stored here
@@ -1588,7 +1582,7 @@ class OpenIDConnectClient
      * @return bool
      */
     public function canVerifySignatures() {
-        return (class_exists('\phpseclib\Crypt\RSA') || class_exists('Crypt_RSA')) and ($this->verifySignature);
+        return class_exists('\phpseclib\Crypt\RSA') || class_exists('Crypt_RSA');
     }
 
     /**

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -991,7 +991,7 @@ class OpenIDConnectClient
             throw new OpenIDConnectClientException('hash_hmac support unavailable.');
         }
 
-        $expected=hash_hmac($hashtype, $payload, $key, true);
+        $expected=hash_hmac($hashtype, $payload, base64_decode($key), true);
 
         if (function_exists('hash_equals')) {
             return hash_equals($signature, $expected);
@@ -1076,9 +1076,9 @@ class OpenIDConnectClient
         return (($this->issuerValidator->__invoke($claims->iss))
             && (($claims->aud === $this->clientID) || in_array($this->clientID, $claims->aud, true))
             && ($this->unsafeDisableNonce || $claims->nonce === $this->getNonce())
-            && ( isset($claims->exp) && ((gettype($claims->exp) === 'integer') && ($claims->exp >= time() - $this->leeway)))
-            && ( isset($claims->iat) && ((gettype($claims->iat) === 'integer') && ($claims->iat <= time() + $this->leeway)))
-            && ( !isset($claims->nbf) || ((gettype($claims->nbf) === 'integer') && ($claims->nbf <= time() + $this->leeway)))
+            && ( isset($claims->exp) && (is_numeric($claims->exp) && ($claims->exp >= time() - $this->leeway)))
+            && ( isset($claims->iat) && (is_numeric($claims->iat) && ($claims->iat <= time() + $this->leeway)))
+            && ( !isset($claims->nbf) || (is_numeric($claims->nbf) && ($claims->nbf <= time() + $this->leeway)))
             && ( !isset($claims->at_hash) || $claims->at_hash === $expected_at_hash )
         );
     }

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -19,10 +19,10 @@
  * under the License.
  *
  * ------------------
- * 
+ *
  * This file was changed by Julius Cordes, 2020-2021.
  * For details see git history.
- * 
+ *
  */
 
 namespace JuliusPC;
@@ -190,8 +190,8 @@ class OpenIDConnectClient
     private $wellKnown = false;
 
     /**
-     * @var mixed holds well-known opendid configuration parameters, like policy for MS Azure AD B2C User Flow  
-     * @see https://docs.microsoft.com/en-us/azure/active-directory-b2c/user-flow-overview 
+     * @var mixed holds well-known opendid configuration parameters, like policy for MS Azure AD B2C User Flow
+     * @see https://docs.microsoft.com/en-us/azure/active-directory-b2c/user-flow-overview
      */
     private $wellKnownConfigParameters = [];
 
@@ -571,7 +571,7 @@ class OpenIDConnectClient
     }
 
     /**
-     * Set optionnal parameters for .well-known/openid-configuration 
+     * Set optionnal parameters for .well-known/openid-configuration
      *
      * @param string $param
      *
@@ -635,7 +635,7 @@ class OpenIDConnectClient
                 ?: @$_SERVER['SERVER_ADDR'];
 
         $port = (443 === $port) || (80 === $port) ? '' : ':' . $port;
-	    
+
 	$uriSplit = explode("?", $_SERVER['REQUEST_URI']);
 
         return sprintf('%s://%s%s/%s', $protocol, $host, $port, @trim(reset($uriSplit), '/'));
@@ -727,7 +727,7 @@ class OpenIDConnectClient
 
     /**
      * Requests an access token with the client credentials grant. This grant is not covered by OpenID Connect.
-     * 
+     *
      * @link https://tools.ietf.org/html/rfc6749#section-4.4
      *
      * @throws OpenIDConnectClientException
@@ -765,7 +765,7 @@ class OpenIDConnectClient
      * This grant will be obsoleted with the upcoming OAuth 2.1 standard. This grant is not covered by OpenID Connect.
      *
      * @link https://tools.ietf.org/html/rfc6749#section-4.3
-     * 
+     *
      * @param boolean $bClientAuth Indicates that the Client ID and Secret be used for client authentication
      * @return mixed
      * @throws OpenIDConnectClientException
@@ -1032,7 +1032,7 @@ class OpenIDConnectClient
             case 'RS512':
                 $hashtype = 'sha' . substr($header->alg, 2);
                 $signatureType = $header->alg === 'PS256' ? 'PSS' : '';
-                
+
                 if (!$this->getProviderConfigValue('jwks_uri')) {
                     throw new OpenIDConnectClientException ('Unable to verify signature due to no jwks_uri being defined');
                 }
@@ -1390,7 +1390,7 @@ class OpenIDConnectClient
     }
 
     /**
-     * @return bool 
+     * @return bool
      */
     public function getHttpUpgradeInsecureRequests()
     {
@@ -1410,7 +1410,7 @@ class OpenIDConnectClient
 
     /**
      * Enables the implicit flow. In most cases you only need the authorization code grant, which is enabled by default.
-     * 
+     *
      * @param bool $allowImplicitFlow
      */
     public function setAllowImplicitFlow($allowImplicitFlow) {
@@ -1492,7 +1492,7 @@ class OpenIDConnectClient
 
     /**
      * Introspect a given token - either access token or refresh token.
-     * 
+     *
      * @link https://tools.ietf.org/html/rfc7662
      *
      * @param string $token
@@ -1901,14 +1901,14 @@ class OpenIDConnectClient
                 $method = 'plain';
             }
         }
-            
+
         return $method;
     }
 
     /**
      * This method allows you to enforce a specific PKCE code challenge method.
      * Useful in cases where your OP supports PKCE but does not announce it in his discovery document.
-     * 
+     *
      * @param string $codeChallengeMethod
      */
     public function setCodeChallengeMethod($codeChallengeMethod) {
@@ -1919,7 +1919,7 @@ class OpenIDConnectClient
      * This method allows you to disable nonce setting and checking.
      * Some OPs seem to have problems with nonces. This behaviour is not compliant to the OIDC spec.
      * Disable it only in case you know what you are doing.
-     * 
+     *
      * @param bool $disableNonce
      */
     public function setUnsafeDisableNonce($disableNonce) {

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1933,10 +1933,14 @@ class OpenIDConnectClient
         return $this->unsafeDisableNonce;
     }
 
+    public function getUnsafeDisablePkce() {
+        return $this->unsafeDisablePkce;
+    }
+
     /**
      * @param bool $disablePkce true to disable use of PKCE
      */
-    public function setUnsafeDisablePkce() {
-        return $this->unsafeDisablePkce;
+    public function setUnsafeDisablePkce($disablePkce) {
+        $this->unsafeDisablePkce = $disablePkce;
     }
 }

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -133,6 +133,12 @@ class OpenIDConnectClient
      * @var bool Verify peer hostname on transactions
      */
     private $verifyHost = true;
+    
+    /**
+     * @var bool Verify JWT signature
+     *
+     */
+    public  $verifySignature = true;
 
     /**
      * @var string if we acquire an access token it will be stored here
@@ -1582,7 +1588,7 @@ class OpenIDConnectClient
      * @return bool
      */
     public function canVerifySignatures() {
-        return class_exists('\phpseclib\Crypt\RSA') || class_exists('Crypt_RSA');
+        return (class_exists('\phpseclib\Crypt\RSA') || class_exists('Crypt_RSA')) and ($this->verifySignature);
     }
 
     /**

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1031,10 +1031,6 @@ class OpenIDConnectClient
             throw new OpenIDConnectClientException('Error decoding JSON from token header');
         }
         $payload = implode('.', $parts);
-        $jwks = json_decode($this->fetchURL($this->getProviderConfigValue('jwks_uri')));
-        if ($jwks === NULL) {
-            throw new OpenIDConnectClientException('Error decoding JSON from jwks_uri');
-        }
         if (!isset($header->alg)) {
             throw new OpenIDConnectClientException('Error missing signature type in token header');
         }
@@ -1045,6 +1041,11 @@ class OpenIDConnectClient
             case 'RS512':
                 $hashtype = 'sha' . substr($header->alg, 2);
                 $signatureType = $header->alg === 'PS256' ? 'PSS' : '';
+                
+                $jwks = json_decode($this->fetchURL($this->getProviderConfigValue('jwks_uri')));
+                if ($jwks === NULL) {
+                    throw new OpenIDConnectClientException('Error decoding JSON from jwks_uri');
+                }
 
                 $verified = $this->verifyRSAJWTsignature($hashtype,
                     $this->getKeyForHeader($jwks->keys, $header),


### PR DESCRIPTION
- Since frameworks handles redirects with responses it should be better to have a method to get the authorization URL without redirect
- Get JWKS only when JWT is signed with RSA

**List of common tasks a pull request require complete**
- [x] Changelog entry is added or the pull request don't alter library's functionality
